### PR TITLE
update fyle accounting version in sage desktop

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ fyle==0.36.1
 
 # Reusable Fyle Packages
 fyle-rest-auth==1.6.0
-fyle-accounting-mappings==1.29.1
+fyle-accounting-mappings==1.30.0
 fyle-integrations-platform-connector==1.36.3
 
 # Postgres Dependincies


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `fyle-accounting-mappings` library to version `1.30.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->