### PR TITLE
use default vendor when vendor is not in destination attribute

### DIFF
--- a/apps/sage300/exports/base_model.py
+++ b/apps/sage300/exports/base_model.py
@@ -90,6 +90,8 @@ class BaseExportModel(models.Model):
                     value__icontains=expense_vendor,
                     attribute_type='VENDOR'
                 ).values_list('destination_id', flat=True).first()
+                if not vendor:
+                    vendor = export_settings.default_vendor_id
             else:
                 vendor = export_settings.default_vendor_id
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling in the Sage 300 application by assigning a default vendor ID when a vendor is not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->