### PR TITLE
fix: delete `expense_attributes_deletion_cache` in workspace reset

### DIFF
--- a/scripts/sql/reset_db.sql
+++ b/scripts/sql/reset_db.sql
@@ -195,6 +195,13 @@ BEGIN
   GET DIAGNOSTICS rcount = ROW_COUNT;
   RAISE NOTICE 'Deleted % users', rcount;
 
+  DELETE
+  FROM expense_attributes_deletion_cache
+  WHERE workspace_id = _workspace_id;
+  GET DIAGNOSTICS rcount = ROW_COUNT;
+  RAISE NOTICE 'Deleted % expense_attributes_deletion_cache', rcount;
+
+
   _org_id := (SELECT org_id FROM workspaces WHERE id = _workspace_id);
 
   DELETE


### PR DESCRIPTION
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved workspace deletion process by adding a new operation to clear related expense attributes.
  
- **Chores**
	- Enhanced database cleanup routines for better data integrity during workspace deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->