### PR TITLE
Feat: Clear existing errors when export type changes

### DIFF
--- a/apps/workspaces/helpers.py
+++ b/apps/workspaces/helpers.py
@@ -85,6 +85,7 @@ def clear_workspace_errors_on_export_type_change(
                 affected_accounting_export_ids = list(AccountingExport.objects.filter(
                     workspace_id=workspace_id,
                     exported_at__isnull=True,
+                    status__in=['FAILED', 'FATAL', 'EXPORT_QUEUED'],
                     fund_source__in=affected_fund_sources
                 ).values_list('id', flat=True))
 

--- a/apps/workspaces/helpers.py
+++ b/apps/workspaces/helpers.py
@@ -1,3 +1,13 @@
+from typing import List
+from django.db import transaction
+
+from apps.accounting_exports.models import AccountingExport, Error
+from apps.workspaces.models import ExportSetting
+import logging
+
+logger = logging.getLogger(__name__)
+
+
 def get_error_model_path() -> str:
     """
     Get error model path: This is for imports submodule
@@ -28,3 +38,90 @@ def get_app_name() -> str:
     :return: str
     """
     return 'SAGE300'
+
+
+def clear_workspace_errors_on_export_type_change(
+    workspace_id: int,
+    old_export_settings: dict,
+    new_export_settings: ExportSetting
+) -> None:
+    """
+    Clear workspace errors when export type settings change.
+    This function clears errors and resets accounting exports when the export type
+    for reimbursable or corporate credit card expenses changes. It ensures that
+    previously failed exports can be re-attempted with the new configuration.
+
+    Args:
+        workspace_id: The workspace ID to clear errors for
+        old_export_settings: Previous export settings as dictionary
+        new_export_settings: New ExportSetting model instance
+    """
+    try:
+        with transaction.atomic():
+            old_reimburse = old_export_settings.get('reimbursable_expenses_export_type')
+            new_reimburse = new_export_settings.reimbursable_expenses_export_type
+            old_ccc = old_export_settings.get('credit_card_expense_export_type')
+            new_ccc = new_export_settings.credit_card_expense_export_type
+
+            reimburse_changed = old_reimburse != new_reimburse
+            ccc_changed = old_ccc != new_ccc
+
+            if reimburse_changed:
+                logger.info("Reimbursable export type changed from '%s' to '%s' in workspace %s", old_reimburse, new_reimburse, workspace_id)
+            if ccc_changed:
+                logger.info("CCC export type changed from '%s' to '%s' in workspace %s", old_ccc, new_ccc, workspace_id)
+
+            affected_fund_sources: List[str] = []
+            if reimburse_changed:
+                affected_fund_sources.append('PERSONAL')
+            if ccc_changed:
+                affected_fund_sources.append('CCC')
+
+            total_deleted_errors = 0
+
+            if affected_fund_sources:
+                logger.info("Export type changed for fund sources %s in workspace %s", affected_fund_sources, workspace_id)
+
+                affected_accounting_export_ids = list(AccountingExport.objects.filter(
+                    workspace_id=workspace_id,
+                    exported_at__isnull=True,
+                    fund_source__in=affected_fund_sources
+                ).values_list('id', flat=True))
+
+                if affected_accounting_export_ids:
+                    logger.info("Found %s affected accounting exports", len(affected_accounting_export_ids))
+
+                    # Clear direct errors for affected accounting exports
+                    accounting_export_errors = Error.objects.filter(
+                        workspace_id=workspace_id,
+                        accounting_export_id__in=affected_accounting_export_ids
+                    )
+                    if accounting_export_errors.exists():
+                        deleted_direct_errors_count, _ = accounting_export_errors.delete()
+                        total_deleted_errors += deleted_direct_errors_count
+                        logger.info("Cleared %s direct accounting export errors", deleted_direct_errors_count)
+
+                    all_mapping_errors = Error.objects.filter(
+                        workspace_id=workspace_id,
+                        type__in=['EMPLOYEE_MAPPING', 'CATEGORY_MAPPING'],
+                        is_resolved=False
+                    )
+                    if all_mapping_errors.exists():
+                        deleted_mapping_errors_count, _ = all_mapping_errors.delete()
+                        total_deleted_errors += deleted_mapping_errors_count
+                        logger.info("Cleared %s mapping errors (all EMPLOYEE_MAPPING and CATEGORY_MAPPING errors)", deleted_mapping_errors_count)
+
+                    updated_exports = AccountingExport.objects.filter(
+                        workspace_id=workspace_id,
+                        id__in=affected_accounting_export_ids,
+                        status__in=['FAILED', 'FATAL', 'EXPORT_QUEUED']
+                    ).update(status='EXPORT_READY', sage300_errors=None, detail=None, mapping_errors=None)
+
+                    if updated_exports > 0:
+                        logger.info("Reset %s accounting exports to EXPORT_READY status", updated_exports)
+
+            logger.info("Successfully cleared %s errors for workspace %s", total_deleted_errors, workspace_id)
+
+    except Exception as e:
+        logger.error("Error clearing workspace errors for workspace %s: %s", workspace_id, str(e))
+        raise

--- a/apps/workspaces/serializers.py
+++ b/apps/workspaces/serializers.py
@@ -12,7 +12,7 @@ from rest_framework import serializers
 
 from apps.accounting_exports.models import AccountingExportSummary
 from apps.fyle.helpers import get_cluster_domain
-from apps.workspaces.triggers import ExportSettingsTrigger
+
 from apps.fyle.models import DependentFieldSetting
 from apps.mappings.models import Version
 from apps.users.models import User
@@ -208,28 +208,9 @@ class ExportSettingsSerializer(serializers.ModelSerializer):
         assert_valid(validated_data, 'Body cannot be null')
         workspace_id = self.context['request'].parser_context.get('kwargs').get('workspace_id')
 
-        existing_export_settings = ExportSetting.objects.filter(workspace_id=workspace_id).first()
-        old_export_settings = {}
-        if existing_export_settings:
-            old_export_settings = {
-                'reimbursable_expenses_export_type': existing_export_settings.reimbursable_expenses_export_type,
-                'credit_card_expense_export_type': existing_export_settings.credit_card_expense_export_type,
-            }
-        else:
-            old_export_settings = {
-                'reimbursable_expenses_export_type': None,
-                'credit_card_expense_export_type': None,
-            }
-
         export_settings, _ = ExportSetting.objects.update_or_create(
             workspace_id=workspace_id,
             defaults=validated_data
-        )
-
-        ExportSettingsTrigger.post_save_workspace_general_settings(
-            workspace_id=workspace_id,
-            export_settings=export_settings,
-            old_configurations=old_export_settings
         )
 
         # Update workspace onboarding state

--- a/apps/workspaces/signals.py
+++ b/apps/workspaces/signals.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.db.models.signals import pre_save
+from django.db.models.signals import pre_save, post_save
 from django.dispatch import receiver
 
 from django_q.tasks import async_task
@@ -8,6 +8,9 @@ from django_q.tasks import async_task
 from fyle_accounting_library.fyle_platform.enums import ExpenseImportSourceEnum, ExpenseStateEnum
 
 from apps.workspaces.models import ExportSetting
+from apps.workspaces.helpers import clear_workspace_errors_on_export_type_change
+from apps.sage300.actions import update_accounting_export_summary
+from apps.accounting_exports.models import AccountingExportSummary
 
 
 logger = logging.getLogger(__name__)
@@ -24,6 +27,10 @@ def run_pre_save_export_settings_triggers(sender: type[ExportSetting], instance:
     ).first()
 
     if existing_export_settings:
+        instance._pre_save_old_export_settings = {
+            'reimbursable_expenses_export_type': existing_export_settings.reimbursable_expenses_export_type,
+            'credit_card_expense_export_type': existing_export_settings.credit_card_expense_export_type,
+        }
         # TODO: move these async_tasks to utility worker later
         is_reimbursable_state_changed = (
             existing_export_settings.reimbursable_expense_state != instance.reimbursable_expense_state
@@ -46,3 +53,33 @@ def run_pre_save_export_settings_triggers(sender: type[ExportSetting], instance:
         if existing_export_settings.credit_card_expense_export_type and is_ccc_state_changed and is_paid_to_approved:
             logger.info(f'Corporate credit card expense state changed from {existing_export_settings.credit_card_expense_state} to {instance.credit_card_expense_state} for workspace {instance.workspace_id}, so pulling the data from Fyle')
             async_task('apps.fyle.tasks.import_expenses', workspace_id=instance.workspace_id, source_account_type='PERSONAL_CORPORATE_CREDIT_CARD_ACCOUNT', fund_source_key='CCC', imported_from=ExpenseImportSourceEnum.CONFIGURATION_UPDATE)
+    else:
+        instance._pre_save_old_export_settings = {
+            'reimbursable_expenses_export_type': None,
+            'credit_card_expense_export_type': None,
+        }
+
+
+@receiver(post_save, sender=ExportSetting)
+def run_post_save_export_settings_triggers(sender: type[ExportSetting], instance: ExportSetting, created: bool, **kwargs) -> None:
+    """
+    Run post save export setting triggers to clear errors when export types change
+    """
+    if hasattr(instance, '_pre_save_old_export_settings'):
+        old_export_settings = instance._pre_save_old_export_settings
+        delattr(instance, '_pre_save_old_export_settings')
+    else:
+        old_export_settings = {
+            'reimbursable_expenses_export_type': None,
+            'credit_card_expense_export_type': None,
+        }
+
+    clear_workspace_errors_on_export_type_change(
+        workspace_id=instance.workspace_id,
+        old_export_settings=old_export_settings,
+        new_export_settings=instance
+    )
+
+    last_export_detail = AccountingExportSummary.objects.filter(workspace_id=instance.workspace_id).first()
+    if last_export_detail and last_export_detail.last_exported_at:
+        update_accounting_export_summary(instance.workspace_id)

--- a/apps/workspaces/triggers.py
+++ b/apps/workspaces/triggers.py
@@ -4,14 +4,11 @@ from typing import Dict, List
 
 from django.conf import settings
 from django.db.models import Q
-from apps.accounting_exports.models import AccountingExportSummary
-from apps.sage300.actions import update_accounting_export_summary
-from apps.workspaces.helpers import clear_workspace_errors_on_export_type_change
 from fyle_accounting_mappings.models import ExpenseAttribute, MappingSetting
 
 from apps.fyle.helpers import post_request
 from apps.mappings.schedules import schedule_or_delete_fyle_import_tasks
-from apps.workspaces.models import AdvancedSetting, ExportSetting, FyleCredential, ImportSetting, Workspace
+from apps.workspaces.models import AdvancedSetting, FyleCredential, ImportSetting, Workspace
 from apps.workspaces.tasks import schedule_sync
 from fyle_integrations_imports.models import ImportLog
 
@@ -157,23 +154,3 @@ class AdvancedSettingsTriggers:
 
         except Exception as error:
             logger.error(error)
-
-
-class ExportSettingsTrigger:
-    """
-    Class containing all triggers for export_settings
-    """
-    @staticmethod
-    def post_save_workspace_general_settings(workspace_id: int, export_settings: ExportSetting, old_configurations: Dict):
-        """
-        Post save action for workspace general settings
-        """
-
-        export_settings: ExportSetting = ExportSetting.objects.filter(workspace_id=workspace_id).first()
-
-        if old_configurations and export_settings:
-            clear_workspace_errors_on_export_type_change(workspace_id, old_configurations, export_settings)
-
-            last_export_detail = AccountingExportSummary.objects.filter(workspace_id=workspace_id).first()
-            if last_export_detail.last_exported_at:
-                update_accounting_export_summary(workspace_id)

--- a/apps/workspaces/triggers.py
+++ b/apps/workspaces/triggers.py
@@ -4,11 +4,14 @@ from typing import Dict, List
 
 from django.conf import settings
 from django.db.models import Q
+from apps.accounting_exports.models import AccountingExportSummary
+from apps.sage300.actions import update_accounting_export_summary
+from apps.workspaces.helpers import clear_workspace_errors_on_export_type_change
 from fyle_accounting_mappings.models import ExpenseAttribute, MappingSetting
 
 from apps.fyle.helpers import post_request
 from apps.mappings.schedules import schedule_or_delete_fyle_import_tasks
-from apps.workspaces.models import AdvancedSetting, FyleCredential, ImportSetting, Workspace
+from apps.workspaces.models import AdvancedSetting, ExportSetting, FyleCredential, ImportSetting, Workspace
 from apps.workspaces.tasks import schedule_sync
 from fyle_integrations_imports.models import ImportLog
 
@@ -154,3 +157,23 @@ class AdvancedSettingsTriggers:
 
         except Exception as error:
             logger.error(error)
+
+
+class ExportSettingsTrigger:
+    """
+    Class containing all triggers for export_settings
+    """
+    @staticmethod
+    def post_save_workspace_general_settings(workspace_id: int, export_settings: ExportSetting, old_configurations: Dict):
+        """
+        Post save action for workspace general settings
+        """
+
+        export_settings: ExportSetting = ExportSetting.objects.filter(workspace_id=workspace_id).first()
+
+        if old_configurations and export_settings:
+            clear_workspace_errors_on_export_type_change(workspace_id, old_configurations, export_settings)
+
+            last_export_detail = AccountingExportSummary.objects.filter(workspace_id=workspace_id).first()
+            if last_export_detail.last_exported_at:
+                update_accounting_export_summary(workspace_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from unittest import mock
 
 import pytest
+from django.db.models.signals import post_save, pre_save
 from fyle.platform.platform import Platform
 from fyle_accounting_mappings.models import (
     CategoryMapping,
@@ -31,6 +32,7 @@ from apps.workspaces.models import (
     Sage300Credential,
     Workspace,
 )
+from apps.workspaces.signals import run_post_save_export_settings_triggers, run_pre_save_export_settings_triggers
 from sage_desktop_api.tests import settings
 from tests.test_fyle.fixtures import fixtures as fyle_fixtures
 
@@ -553,28 +555,80 @@ def add_export_settings():
     """
     Pytest fixtue to add export_settings to a workspace
     """
-
     workspace_ids = [
         1, 2, 3
     ]
 
-    for workspace_id in workspace_ids:
-        ExportSetting.objects.create(
-            workspace_id=workspace_id,
-            reimbursable_expenses_export_type='PURCHASE_INVOICE' if workspace_id in [1, 2] else 'DIRECT_COST',
-            default_bank_account_name='Accounts Payable',
-            default_back_account_id='1',
-            reimbursable_expense_state='PAYMENT_PROCESSING',
-            reimbursable_expense_date='SPENT_AT' if workspace_id == 1 else 'LAST_SPENT_AT',
-            reimbursable_expense_grouped_by='REPORT' if workspace_id == 1 else 'EXPENSE',
-            credit_card_expense_export_type='DIRECT_COST' if workspace_id in [1, 2] else 'PURCHASE_INVOICE',
-            credit_card_expense_state='PAYMENT_PROCESSING',
-            default_ccc_credit_card_account_name='Visa',
-            default_ccc_credit_card_account_id='12',
-            credit_card_expense_grouped_by='EXPENSE' if workspace_id == 3 else 'REPORT',
-            credit_card_expense_date='SPENT_AT',
-            default_vendor_id='1',
-        )
+    # Temporarily disconnect the signals to avoid triggering error clearing during test setup
+    post_save.disconnect(run_post_save_export_settings_triggers, sender=ExportSetting)
+    pre_save.disconnect(run_pre_save_export_settings_triggers, sender=ExportSetting)
+
+    try:
+        for workspace_id in workspace_ids:
+            ExportSetting.objects.create(
+                workspace_id=workspace_id,
+                reimbursable_expenses_export_type='PURCHASE_INVOICE' if workspace_id in [1, 2] else 'DIRECT_COST',
+                default_bank_account_name='Accounts Payable',
+                default_back_account_id='1',
+                reimbursable_expense_state='PAYMENT_PROCESSING',
+                reimbursable_expense_date='SPENT_AT' if workspace_id == 1 else 'LAST_SPENT_AT',
+                reimbursable_expense_grouped_by='REPORT' if workspace_id == 1 else 'EXPENSE',
+                credit_card_expense_export_type='DIRECT_COST' if workspace_id in [1, 2] else 'PURCHASE_INVOICE',
+                credit_card_expense_state='PAYMENT_PROCESSING',
+                default_ccc_credit_card_account_name='Visa',
+                default_ccc_credit_card_account_id='12',
+                credit_card_expense_grouped_by='EXPENSE' if workspace_id == 3 else 'REPORT',
+                credit_card_expense_date='SPENT_AT',
+                default_vendor_id='1',
+            )
+    finally:
+        # Reconnect the signals after creating the test data
+        post_save.connect(run_post_save_export_settings_triggers, sender=ExportSetting)
+        pre_save.connect(run_pre_save_export_settings_triggers, sender=ExportSetting)
+
+
+@pytest.fixture()
+@pytest.mark.django_db(databases=['default'])
+def simple_export_settings(create_temp_workspace):
+    """
+    Simple fixture to create export settings without triggering signals
+    """
+    workspace_id = 1
+    export_setting = ExportSetting.objects.create(
+        workspace_id=workspace_id,
+        reimbursable_expenses_export_type='PURCHASE_INVOICE',
+        credit_card_expense_export_type='DIRECT_COST',
+        default_bank_account_name='Test Account',
+        default_back_account_id='1',
+        reimbursable_expense_state='PAYMENT_PROCESSING',
+        reimbursable_expense_date='SPENT_AT',
+        reimbursable_expense_grouped_by='REPORT',
+        credit_card_expense_state='PAYMENT_PROCESSING',
+        default_ccc_credit_card_account_name='Visa',
+        default_ccc_credit_card_account_id='12',
+        credit_card_expense_grouped_by='REPORT',
+        credit_card_expense_date='SPENT_AT',
+        default_vendor_id='1',
+    )
+    return export_setting
+
+
+@pytest.fixture()
+@pytest.mark.django_db(databases=['default'])
+def simple_accounting_export_summary(create_temp_workspace):
+    """
+    Simple fixture to create accounting export summary
+    """
+    workspace_id = 1
+    summary = AccountingExportSummary.objects.create(
+        workspace_id=workspace_id,
+        last_exported_at='2024-01-01T00:00:00Z',
+        export_mode='AUTO',
+        total_accounting_export_count=0,
+        successful_accounting_export_count=0,
+        failed_accounting_export_count=0
+    )
+    return summary
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -564,7 +564,6 @@ def add_export_settings():
         1, 2, 3
     ]
 
-    # Temporarily disconnect the signals to avoid triggering error clearing during test setup
     post_save.disconnect(run_post_save_export_settings_triggers, sender=ExportSetting)
     pre_save.disconnect(run_pre_save_export_settings_triggers, sender=ExportSetting)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -365,6 +365,11 @@ def add_basic_credit_card_exports():
     Creates basic credit card exports for testing
     """
     workspace_id = 1
+    AccountingExport.objects.filter(
+        workspace_id=workspace_id,
+        fund_source='CCC',
+        type='DIRECT_COST'
+    ).delete()
 
     AccountingExport.objects.create(
         workspace_id=workspace_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -567,13 +567,13 @@ def add_export_settings():
         for workspace_id in workspace_ids:
             ExportSetting.objects.create(
                 workspace_id=workspace_id,
-                reimbursable_expenses_export_type='PURCHASE_INVOICE' if workspace_id in [1, 2] else 'DIRECT_COST',
+                reimbursable_expenses_export_type='PURCHASE_INVOICE',
                 default_bank_account_name='Accounts Payable',
                 default_back_account_id='1',
                 reimbursable_expense_state='PAYMENT_PROCESSING',
                 reimbursable_expense_date='SPENT_AT' if workspace_id == 1 else 'LAST_SPENT_AT',
                 reimbursable_expense_grouped_by='REPORT' if workspace_id == 1 else 'EXPENSE',
-                credit_card_expense_export_type='DIRECT_COST' if workspace_id in [1, 2] else 'PURCHASE_INVOICE',
+                credit_card_expense_export_type=None,
                 credit_card_expense_state='PAYMENT_PROCESSING',
                 default_ccc_credit_card_account_name='Visa',
                 default_ccc_credit_card_account_id='12',
@@ -597,7 +597,7 @@ def simple_export_settings(create_temp_workspace):
     export_setting = ExportSetting.objects.create(
         workspace_id=workspace_id,
         reimbursable_expenses_export_type='PURCHASE_INVOICE',
-        credit_card_expense_export_type='DIRECT_COST',
+        credit_card_expense_export_type='PURCHASE_INVOICE',
         default_bank_account_name='Test Account',
         default_back_account_id='1',
         reimbursable_expense_state='PAYMENT_PROCESSING',

--- a/tests/test_sage300/test_exports/test_queues.py
+++ b/tests/test_sage300/test_exports/test_queues.py
@@ -77,68 +77,6 @@ def test_poll_operation_status_purchase_invoice(
     assert accounting_export.first().status == 'FAILED'
 
 
-def test_direct_cost_poll_operation_status(
-    db,
-    mocker,
-    create_temp_workspace,
-    add_sage300_creds,
-    add_fyle_credentials,
-    add_accounting_export_expenses
-):
-    """
-    function to test poll operation status
-    """
-    operation_status = {
-        "Id": "e0d57177-2700-49a1-a933-b0c900bf1c4e",
-        "CreatedOn": "2023-11-29T18:35:48.8712983",
-        "TransmittedOn": "2023-11-29T18:35:49.5785546",
-        "ReceivedOn": "2023-11-29T18:35:49.7466667",
-        "DisabledOn": "2023-11-29T18:36:01.6307696",
-        "CompletedOn": "2023-11-29T18:36:01.6307696"
-    }
-
-    mock_sage_connector = mocker.patch(
-        'apps.sage300.exports.direct_cost.queues.SageDesktopConnector'
-    )
-
-    mock_sage_connector.return_value.connection.operation_status.get.return_value = operation_status
-    mock_sage_connector.return_value.update_cookie.return_value = {'text': {'Result': 2}}
-    mock_sage_connector.return_value.connection.documents.get.return_value = {
-        'CurrentState': '9'
-    }
-    mock_sage_connector.return_value.connection.event_failures.get.return_value = [
-        {
-            "CreatedOnUtc": "2023-08-17T09:46:30Z",
-            "EntityId": "728406bd-32f6-4676-95ff-b06100a0f840",
-            "ErrorMessage": "Exception of type 'DBI.Synchronization.Processing.TimberlineOffice.KeyAlreadyInUseException' was thrown.",
-            "Id": "6615abdf-733f-4190-a4ed-b06100a1166f",
-            "TypeId": "4de325f1-a380-41cc-90ce-be1e02fef167",
-            "Version": 12967
-        },
-    ]
-
-    accounting_export = AccountingExport.objects.filter(workspace_id=1, type='DIRECT_COST').first()
-    assert accounting_export.status == 'EXPORT_QUEUED'
-
-    poll_operation_status_direct_cost(workspace_id=1)
-
-    accounting_export = AccountingExport.objects.filter(workspace_id=1, type='DIRECT_COST').first()
-    assert accounting_export.status == 'COMPLETE'
-
-    mock_sage_connector.return_value.connection.documents.get.return_value = {
-        'CurrentState': '6'
-    }
-
-    accounting_export.status = 'EXPORT_QUEUED'
-    accounting_export.save()
-
-    poll_operation_status_direct_cost(workspace_id=1)
-    accounting_export = AccountingExport.objects.filter(workspace_id=1, type='DIRECT_COST')
-
-    assert accounting_export.count() == 1
-    assert accounting_export.first().status == 'FAILED'
-
-
 def test_check_accounting_export_and_start_import_purchase_invoice(
     db,
     create_temp_workspace,
@@ -212,6 +150,68 @@ def test_create_schedule_for_polling_purchase_invoice(
     ).first()
 
     assert schedule is not None
+
+
+def test_direct_cost_poll_operation_status(
+    db,
+    mocker,
+    create_temp_workspace,
+    add_sage300_creds,
+    add_fyle_credentials,
+    add_accounting_export_expenses
+):
+    """
+    function to test poll operation status
+    """
+    operation_status = {
+        "Id": "e0d57177-2700-49a1-a933-b0c900bf1c4e",
+        "CreatedOn": "2023-11-29T18:35:48.8712983",
+        "TransmittedOn": "2023-11-29T18:35:49.5785546",
+        "ReceivedOn": "2023-11-29T18:35:49.7466667",
+        "DisabledOn": "2023-11-29T18:36:01.6307696",
+        "CompletedOn": "2023-11-29T18:36:01.6307696"
+    }
+
+    mock_sage_connector = mocker.patch(
+        'apps.sage300.exports.direct_cost.queues.SageDesktopConnector'
+    )
+
+    mock_sage_connector.return_value.connection.operation_status.get.return_value = operation_status
+    mock_sage_connector.return_value.update_cookie.return_value = {'text': {'Result': 2}}
+    mock_sage_connector.return_value.connection.documents.get.return_value = {
+        'CurrentState': '9'
+    }
+    mock_sage_connector.return_value.connection.event_failures.get.return_value = [
+        {
+            "CreatedOnUtc": "2023-08-17T09:46:30Z",
+            "EntityId": "728406bd-32f6-4676-95ff-b06100a0f840",
+            "ErrorMessage": "Exception of type 'DBI.Synchronization.Processing.TimberlineOffice.KeyAlreadyInUseException' was thrown.",
+            "Id": "6615abdf-733f-4190-a4ed-b06100a1166f",
+            "TypeId": "4de325f1-a380-41cc-90ce-be1e02fef167",
+            "Version": 12967
+        },
+    ]
+
+    accounting_export = AccountingExport.objects.filter(workspace_id=1, type='DIRECT_COST').first()
+    assert accounting_export.status == 'EXPORT_QUEUED'
+
+    poll_operation_status_direct_cost(workspace_id=1)
+
+    accounting_export = AccountingExport.objects.filter(workspace_id=1, type='DIRECT_COST').first()
+    assert accounting_export.status == 'COMPLETE'
+
+    mock_sage_connector.return_value.connection.documents.get.return_value = {
+        'CurrentState': '6'
+    }
+
+    accounting_export.status = 'EXPORT_QUEUED'
+    accounting_export.save()
+
+    poll_operation_status_direct_cost(workspace_id=1)
+    accounting_export = AccountingExport.objects.filter(workspace_id=1, type='DIRECT_COST')
+
+    assert accounting_export.count() == 1
+    assert accounting_export.first().status == 'FAILED'
 
 
 def test_check_accounting_export_and_start_import_direct_cost(
@@ -289,6 +289,67 @@ def test_create_schedule_for_polling_direct_cost(
     assert schedule is not None
 
 
+def test_skipping_direct_cost(
+    db,
+    create_temp_workspace,
+    add_fyle_credentials,
+    add_export_settings,
+    add_accounting_export_expenses,
+    mocker
+):
+    """
+    Test check_accounting_export_and_start_import for purchase invoice
+    """
+    workspace_id = 1
+    accounting_export = AccountingExport.objects.filter(workspace_id=workspace_id, type='DIRECT_COST').first()
+    accounting_export.status = ''
+    accounting_export.exported_at = None
+    accounting_export.save()
+
+    error = Error.objects.filter(workspace_id=workspace_id, accounting_export=accounting_export).delete()
+
+    error = Error.objects.create(
+        workspace_id=workspace_id,
+        type='NETSUITE_ERROR',
+        error_title='NetSuite System Error',
+        error_detail='An error occured in a upsert request: Please enter value(s) for: Location',
+        accounting_export=accounting_export,
+        repetition_count=106
+    )
+
+    mocker.patch('apps.sage300.exports.direct_cost.tasks.create_direct_cost')
+    mocker.patch('apps.fyle.helpers.sync_dimensions')
+    mocker.patch('django_q.tasks.Chain.run')
+
+    check_accounting_export_and_start_import_direct_cost(
+        accounting_export.workspace_id,
+        [accounting_export.id],
+        True,
+        1,
+        ExpenseImportSourceEnum.DIRECT_EXPORT
+    )
+
+    accounting_export.refresh_from_db()
+
+    assert accounting_export.status == ''
+    assert accounting_export.type == 'DIRECT_COST'
+
+    Error.objects.filter(id=error.id).update(updated_at=datetime(2024, 8, 20))
+
+    check_accounting_export_and_start_import_direct_cost(
+        accounting_export.workspace_id,
+        [accounting_export.id],
+        True,
+        1,
+        ExpenseImportSourceEnum.DIRECT_EXPORT
+    )
+
+    accounting_export.refresh_from_db()
+
+    assert accounting_export.status == 'ENQUEUED'
+    assert accounting_export.type == 'DIRECT_COST'
+
+
 def test_skipping_purchase_invoice(
     db,
     create_temp_workspace,
@@ -345,64 +406,3 @@ def test_skipping_purchase_invoice(
 
     assert accounting_export.status == 'ENQUEUED'
     assert accounting_export.type == 'PURCHASE_INVOICE'
-
-
-def test_skipping_direct_cost(
-    db,
-    create_temp_workspace,
-    add_fyle_credentials,
-    add_export_settings,
-    add_accounting_export_expenses,
-    mocker
-):
-    """
-    Test check_accounting_export_and_start_import for purchase invoice
-    """
-    workspace_id = 1
-    accounting_export = AccountingExport.objects.filter(workspace_id=workspace_id, type='DIRECT_COST').first()
-    accounting_export.status = ''
-    accounting_export.exported_at = None
-    accounting_export.save()
-
-    error = Error.objects.filter(workspace_id=workspace_id, accounting_export=accounting_export).delete()
-
-    error = Error.objects.create(
-        workspace_id=workspace_id,
-        type='NETSUITE_ERROR',
-        error_title='NetSuite System Error',
-        error_detail='An error occured in a upsert request: Please enter value(s) for: Location',
-        accounting_export=accounting_export,
-        repetition_count=106
-    )
-
-    mocker.patch('apps.sage300.exports.direct_cost.tasks.create_direct_cost')
-    mocker.patch('apps.fyle.helpers.sync_dimensions')
-    mocker.patch('django_q.tasks.Chain.run')
-
-    check_accounting_export_and_start_import(
-        accounting_export.workspace_id,
-        [accounting_export.id],
-        True,
-        1,
-        ExpenseImportSourceEnum.DIRECT_EXPORT
-    )
-
-    accounting_export.refresh_from_db()
-
-    assert accounting_export.status == ''
-    assert accounting_export.type == 'DIRECT_COST'
-
-    Error.objects.filter(id=error.id).update(updated_at=datetime(2024, 8, 20))
-
-    check_accounting_export_and_start_import(
-        accounting_export.workspace_id,
-        [accounting_export.id],
-        True,
-        1,
-        ExpenseImportSourceEnum.DIRECT_EXPORT
-    )
-
-    accounting_export.refresh_from_db()
-
-    assert accounting_export.status == 'ENQUEUED'
-    assert accounting_export.type == 'DIRECT_COST'

--- a/tests/test_workspaces/test_helpers.py
+++ b/tests/test_workspaces/test_helpers.py
@@ -1,0 +1,371 @@
+import pytest
+from unittest.mock import patch
+
+from apps.accounting_exports.models import AccountingExport, Error
+from apps.workspaces.helpers import clear_workspace_errors_on_export_type_change
+from apps.workspaces.models import ExportSetting
+
+
+def test_clear_workspace_errors_no_changes(
+    db,
+    create_temp_workspace,
+    add_accounting_export_expenses,
+    add_errors,
+    add_export_settings
+):
+    workspace_id = 1
+
+    old_export_settings = {
+        'reimbursable_expenses_export_type': 'PURCHASE_INVOICE',
+        'credit_card_expense_export_type': 'DIRECT_COST'
+    }
+
+    export_setting = ExportSetting.objects.get(workspace_id=workspace_id)
+    initial_error_count = Error.objects.filter(workspace_id=workspace_id).count()
+
+    clear_workspace_errors_on_export_type_change(
+        workspace_id=workspace_id,
+        old_export_settings=old_export_settings,
+        new_export_settings=export_setting
+    )
+
+    assert Error.objects.filter(workspace_id=workspace_id).count() == initial_error_count
+
+    personal_export = AccountingExport.objects.filter(fund_source='PERSONAL').first()
+    ccc_export = AccountingExport.objects.filter(fund_source='CCC').first()
+    assert personal_export.status == 'EXPORT_QUEUED'
+    assert ccc_export.status == 'EXPORT_QUEUED'
+
+
+def test_clear_workspace_errors_reimbursable_change(
+    db,
+    create_temp_workspace,
+    add_accounting_export_expenses,
+    add_errors,
+    add_export_settings
+):
+    workspace_id = 1
+
+    old_export_settings = {
+        'reimbursable_expenses_export_type': 'DIRECT_COST',
+        'credit_card_expense_export_type': 'DIRECT_COST'
+    }
+
+    export_setting = ExportSetting.objects.get(workspace_id=workspace_id)
+
+    clear_workspace_errors_on_export_type_change(
+        workspace_id=workspace_id,
+        old_export_settings=old_export_settings,
+        new_export_settings=export_setting
+    )
+
+    mapping_errors = Error.objects.filter(
+        workspace_id=workspace_id,
+        type__in=['EMPLOYEE_MAPPING', 'CATEGORY_MAPPING'],
+        is_resolved=False
+    )
+    assert mapping_errors.count() == 0
+
+    personal_exports = AccountingExport.objects.filter(
+        workspace_id=workspace_id,
+        fund_source='PERSONAL',
+        exported_at__isnull=True,
+        status='EXPORT_READY'
+    )
+    assert personal_exports.exists()
+
+
+def test_clear_workspace_errors_ccc_change(
+    db,
+    create_temp_workspace,
+    add_accounting_export_expenses,
+    add_errors,
+    add_export_settings
+):
+    workspace_id = 1
+
+    old_export_settings = {
+        'reimbursable_expenses_export_type': 'PURCHASE_INVOICE',
+        'credit_card_expense_export_type': 'PURCHASE_INVOICE'
+    }
+
+    export_setting = ExportSetting.objects.get(workspace_id=workspace_id)
+
+    clear_workspace_errors_on_export_type_change(
+        workspace_id=workspace_id,
+        old_export_settings=old_export_settings,
+        new_export_settings=export_setting
+    )
+
+    mapping_errors = Error.objects.filter(
+        workspace_id=workspace_id,
+        type__in=['EMPLOYEE_MAPPING', 'CATEGORY_MAPPING'],
+        is_resolved=False
+    )
+    assert mapping_errors.count() == 0
+
+    ccc_exports = AccountingExport.objects.filter(
+        workspace_id=workspace_id,
+        fund_source='CCC',
+        exported_at__isnull=True,
+        status='EXPORT_READY'
+    )
+    assert ccc_exports.exists()
+
+
+def test_clear_workspace_errors_both_types_change(
+    db,
+    create_temp_workspace,
+    add_accounting_export_expenses,
+    add_errors,
+    add_export_settings
+):
+    workspace_id = 1
+
+    old_export_settings = {
+        'reimbursable_expenses_export_type': 'DIRECT_COST',
+        'credit_card_expense_export_type': 'PURCHASE_INVOICE'
+    }
+
+    export_setting = ExportSetting.objects.get(workspace_id=workspace_id)
+
+    clear_workspace_errors_on_export_type_change(
+        workspace_id=workspace_id,
+        old_export_settings=old_export_settings,
+        new_export_settings=export_setting
+    )
+
+    mapping_errors = Error.objects.filter(
+        workspace_id=workspace_id,
+        type__in=['EMPLOYEE_MAPPING', 'CATEGORY_MAPPING'],
+        is_resolved=False
+    )
+    assert mapping_errors.count() == 0
+
+    personal_exports = AccountingExport.objects.filter(
+        workspace_id=workspace_id,
+        fund_source='PERSONAL',
+        exported_at__isnull=True,
+        status='EXPORT_READY'
+    )
+    ccc_exports = AccountingExport.objects.filter(
+        workspace_id=workspace_id,
+        fund_source='CCC',
+        exported_at__isnull=True,
+        status='EXPORT_READY'
+    )
+    assert personal_exports.exists()
+    assert ccc_exports.exists()
+
+
+def test_clear_workspace_errors_enable_from_none(
+    db,
+    create_temp_workspace,
+    add_accounting_export_expenses,
+    add_errors,
+    add_export_settings
+):
+    workspace_id = 1
+
+    old_export_settings = {
+        'reimbursable_expenses_export_type': None,
+        'credit_card_expense_export_type': 'DIRECT_COST'
+    }
+
+    export_setting = ExportSetting.objects.get(workspace_id=workspace_id)
+
+    clear_workspace_errors_on_export_type_change(
+        workspace_id=workspace_id,
+        old_export_settings=old_export_settings,
+        new_export_settings=export_setting
+    )
+
+    mapping_errors = Error.objects.filter(
+        workspace_id=workspace_id,
+        type__in=['EMPLOYEE_MAPPING', 'CATEGORY_MAPPING'],
+        is_resolved=False
+    )
+    assert mapping_errors.count() == 0
+
+    personal_exports = AccountingExport.objects.filter(
+        workspace_id=workspace_id,
+        fund_source='PERSONAL',
+        exported_at__isnull=True,
+        status='EXPORT_READY'
+    )
+    assert personal_exports.exists()
+
+
+def test_clear_workspace_errors_disable_to_none(
+    db,
+    create_temp_workspace,
+    add_accounting_export_expenses,
+    add_errors
+):
+    workspace_id = 1
+
+    export_setting = ExportSetting.objects.create(
+        workspace_id=workspace_id,
+        reimbursable_expenses_export_type=None,
+        credit_card_expense_export_type='DIRECT_COST'
+    )
+
+    old_export_settings = {
+        'reimbursable_expenses_export_type': 'PURCHASE_INVOICE',
+        'credit_card_expense_export_type': 'DIRECT_COST'
+    }
+
+    clear_workspace_errors_on_export_type_change(
+        workspace_id=workspace_id,
+        old_export_settings=old_export_settings,
+        new_export_settings=export_setting
+    )
+
+    mapping_errors = Error.objects.filter(
+        workspace_id=workspace_id,
+        type__in=['EMPLOYEE_MAPPING', 'CATEGORY_MAPPING'],
+        is_resolved=False
+    )
+    assert mapping_errors.count() == 0
+
+
+def test_clear_workspace_errors_only_unresolved_deleted(
+    db,
+    create_temp_workspace,
+    add_accounting_export_expenses,
+    add_export_settings
+):
+    workspace_id = 1
+    accounting_export = AccountingExport.objects.filter(workspace_id=workspace_id).first()
+
+    resolved_error = Error.objects.create(
+        workspace_id=workspace_id,
+        type='EMPLOYEE_MAPPING',
+        accounting_export=accounting_export,
+        error_title='Resolved Mapping Error',
+        error_detail='Employee mapping missing',
+        is_resolved=True
+    )
+
+    old_export_settings = {
+        'reimbursable_expenses_export_type': 'DIRECT_COST',
+        'credit_card_expense_export_type': 'DIRECT_COST'
+    }
+
+    export_setting = ExportSetting.objects.get(workspace_id=workspace_id)
+
+    clear_workspace_errors_on_export_type_change(
+        workspace_id=workspace_id,
+        old_export_settings=old_export_settings,
+        new_export_settings=export_setting
+    )
+
+    assert Error.objects.filter(id=resolved_error.id).exists()
+
+    unresolved_errors = Error.objects.filter(
+        workspace_id=workspace_id,
+        type__in=['EMPLOYEE_MAPPING', 'CATEGORY_MAPPING'],
+        is_resolved=False
+    )
+    assert unresolved_errors.count() == 0
+
+
+@patch('apps.workspaces.helpers.logger')
+def test_clear_workspace_errors_logging(
+    mock_logger,
+    db,
+    create_temp_workspace,
+    add_accounting_export_expenses,
+    add_errors,
+    add_export_settings
+):
+    workspace_id = 1
+
+    old_export_settings = {
+        'reimbursable_expenses_export_type': 'DIRECT_COST',
+        'credit_card_expense_export_type': 'PURCHASE_INVOICE'
+    }
+
+    export_setting = ExportSetting.objects.get(workspace_id=workspace_id)
+
+    clear_workspace_errors_on_export_type_change(
+        workspace_id=workspace_id,
+        old_export_settings=old_export_settings,
+        new_export_settings=export_setting
+    )
+
+    mock_logger.info.assert_any_call(
+        "Reimbursable export type changed from '%s' to '%s' in workspace %s",
+        'DIRECT_COST', 'PURCHASE_INVOICE', workspace_id
+    )
+    mock_logger.info.assert_any_call(
+        "CCC export type changed from '%s' to '%s' in workspace %s",
+        'PURCHASE_INVOICE', 'DIRECT_COST', workspace_id
+    )
+
+
+def test_clear_workspace_errors_exception_handling(
+    db,
+    create_temp_workspace,
+    add_accounting_export_expenses,
+    add_errors
+):
+    workspace_id = 1
+
+    old_export_settings = {
+        'reimbursable_expenses_export_type': 'DIRECT_COST',
+        'credit_card_expense_export_type': 'DIRECT_COST'
+    }
+
+    invalid_export_setting = None
+
+    with pytest.raises(AttributeError):
+        clear_workspace_errors_on_export_type_change(
+            workspace_id=workspace_id,
+            old_export_settings=old_export_settings,
+            new_export_settings=invalid_export_setting
+        )
+
+
+def test_clear_workspace_errors_exported_accounting_exports_unchanged(
+    db,
+    create_temp_workspace,
+    add_export_settings
+):
+    workspace_id = 1
+
+    exported_export = AccountingExport.objects.create(
+        workspace_id=workspace_id,
+        type='PURCHASE_INVOICE',
+        fund_source='PERSONAL',
+        status='FAILED',
+        exported_at='2024-01-01T00:00:00Z'
+    )
+
+    unexported_export = AccountingExport.objects.create(
+        workspace_id=workspace_id,
+        type='PURCHASE_INVOICE',
+        fund_source='PERSONAL',
+        status='FAILED',
+        exported_at=None
+    )
+
+    old_export_settings = {
+        'reimbursable_expenses_export_type': 'DIRECT_COST',
+        'credit_card_expense_export_type': 'DIRECT_COST'
+    }
+
+    export_setting = ExportSetting.objects.get(workspace_id=workspace_id)
+
+    clear_workspace_errors_on_export_type_change(
+        workspace_id=workspace_id,
+        old_export_settings=old_export_settings,
+        new_export_settings=export_setting
+    )
+
+    exported_export.refresh_from_db()
+    assert exported_export.status == 'FAILED'
+    assert exported_export.exported_at is not None
+
+    unexported_export.refresh_from_db()
+    assert unexported_export.status == 'EXPORT_READY'

--- a/tests/test_workspaces/test_helpers.py
+++ b/tests/test_workspaces/test_helpers.py
@@ -31,8 +31,8 @@ def test_clear_workspace_errors_no_changes(
 
     assert Error.objects.filter(workspace_id=workspace_id).count() == initial_error_count
 
-    personal_export = AccountingExport.objects.filter(fund_source='PERSONAL').first()
-    ccc_export = AccountingExport.objects.filter(fund_source='CCC').first()
+    personal_export = AccountingExport.objects.filter(workspace_id=workspace_id, fund_source='PERSONAL').first()
+    ccc_export = AccountingExport.objects.filter(workspace_id=workspace_id, fund_source='CCC').first()
     assert personal_export.status == 'EXPORT_QUEUED'
     assert ccc_export.status == 'EXPORT_QUEUED'
 

--- a/tests/test_workspaces/test_signals.py
+++ b/tests/test_workspaces/test_signals.py
@@ -34,6 +34,7 @@ def test_run_pre_save_export_settings_triggers_ccc_state_change(db, mocker, crea
     workspace_id = 2
 
     existing_export_setting = ExportSetting.objects.get(workspace_id=workspace_id)
+    existing_export_setting.credit_card_expense_export_type = 'PURCHASE_INVOICE'
     existing_export_setting.credit_card_expense_state = ExpenseStateEnum.PAID
     existing_export_setting.save()
 
@@ -58,6 +59,7 @@ def test_run_pre_save_export_settings_triggers_both_state_changes(db, mocker, cr
     workspace_id = 3
 
     existing_export_setting = ExportSetting.objects.get(workspace_id=workspace_id)
+    existing_export_setting.credit_card_expense_export_type = 'PURCHASE_INVOICE'
     existing_export_setting.reimbursable_expense_state = ExpenseStateEnum.PAID
     existing_export_setting.credit_card_expense_state = ExpenseStateEnum.PAID
     existing_export_setting.save()


### PR DESCRIPTION
http://app.clickup.com/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - When reimbursable or corporate-card export types change, unresolved mapping/accounting errors are cleared and unexported items are reset to Export Ready.
  - Export summary now auto-refreshes after export-setting changes when prior exports exist.

- Tests
  - Added tests covering export-type change behavior, error-state transitions, and signal triggers.
  - Re-enabled and expanded Direct Cost export workflow tests (polling, importing, scheduling).
  - New fixtures to support deterministic export-setting and summary scenarios.

- Style
  - Minor formatting cleanup in serializers (no behavioral change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->